### PR TITLE
fix: validate trace step ordering

### DIFF
--- a/skills/security-audit/report-schema.json
+++ b/skills/security-audit/report-schema.json
@@ -55,7 +55,7 @@
               "required": ["kind", "file", "line", "scope", "description"],
               "additionalProperties": false
             },
-            "description": "Sequential code trace from entrypoint to sink, verified against actual source code. The first step must be kind 'entrypoint' and the last must be kind 'sink' (enforced by the validator)."
+            "description": "Sequential code trace from entrypoint to sink, verified against actual source code. The first step must be kind 'entrypoint', the last must be kind 'sink', and any intermediate steps must be kind 'propagation' (enforced by the validator)."
           },
           "conditions": {
             "type": "array",

--- a/skills/security-audit/validate-findings.cjs
+++ b/skills/security-audit/validate-findings.cjs
@@ -9,9 +9,10 @@
  * Schema it uses: type (object|array|string|integer), properties, required,
  * additionalProperties:false, enum, const, items, minItems, and oneOf.
  *
- * Two constraints can't be expressed in that subset (a confirmed trace must
- * start at an "entrypoint" and end at a "sink"). They're applied as an explicit,
- * clearly-labelled semantic layer after schema validation.
+ * Some constraints can't be expressed in that subset (a confirmed trace must
+ * start at an "entrypoint", end at a "sink", and only use "propagation" for
+ * intermediate steps). They're applied as an explicit, clearly-labelled
+ * semantic layer after schema validation.
  *
  * Zero dependencies. Exits 0 on success, 1 on validation failure.
  */
@@ -170,7 +171,8 @@ findings.forEach((f, i) => {
 	const errs = collect(f, itemSchema, `[${i}]`);
 
 	// Semantic layer — constraints the schema subset can't express:
-	// a confirmed trace must start at an entrypoint and end at a sink.
+	// a confirmed trace must be one entrypoint, zero or more propagation steps,
+	// then one sink.
 	if (f && f.verdict === "confirmed" && Array.isArray(f.trace) && f.trace.length > 0) {
 		if (f.trace[0] && f.trace[0].kind !== "entrypoint") {
 			errs.push(`[${i}].trace[0].kind must be "entrypoint", got ${JSON.stringify(f.trace[0].kind)}`);
@@ -178,6 +180,11 @@ findings.forEach((f, i) => {
 		const last = f.trace.length - 1;
 		if (f.trace[last] && f.trace[last].kind !== "sink") {
 			errs.push(`[${i}].trace[${last}].kind must be "sink", got ${JSON.stringify(f.trace[last].kind)}`);
+		}
+		for (let j = 1; j < last; j++) {
+			if (f.trace[j] && f.trace[j].kind !== "propagation") {
+				errs.push(`[${i}].trace[${j}].kind must be "propagation", got ${JSON.stringify(f.trace[j].kind)}`);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Tightens `validate-findings.cjs` so confirmed traces must follow the documented shape: one `entrypoint`, zero or more `propagation` steps, then one `sink`.

This prevents malformed `findings.json` traces such as `entrypoint -> entrypoint -> sink` from passing the semantic validation layer before Phase 6 verification.

## Validation

- `node --check skills/security-audit/validate-findings.cjs`
- Valid fixture with `entrypoint -> propagation -> sink` passes
- Invalid fixture with `entrypoint -> entrypoint -> sink` fails with the new middle-step error
- `git diff --check`
