### PR TITLE
feat: add findings.json → SARIF 2.1.0 converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ The skill runs a structured audit in six phases:
 
 Multiple runs against the same repo are additive. Each run explores different code paths; the skill reads prior `findings.json` files to skip known issues and target gaps.
 
+### SARIF export
+
+To feed audit results into GitHub code scanning, VS Code SARIF viewers, or any
+other SARIF consumer, convert `findings.json` to SARIF 2.1.0:
+
+```bash
+node findings-to-sarif.cjs <output-dir>/findings.json <output-dir>/findings.sarif
+```
+
+Confirmed findings become SARIF results; each finding's `trace` maps to a
+`codeFlow` (entrypoint → sink) that GitHub code scanning renders as a
+step-through path, and `overall_severity` maps to the code-scanning severity
+buckets. Rejected findings are excluded from results but counted in
+`run.properties` so the audit trail stays intact.
+
 ## Files
 
 | File | Purpose |
@@ -32,6 +47,7 @@ Multiple runs against the same repo are additive. Each run explores different co
 | `VALIDATION-AND-REPORTING.md` | Phases 3–6 validation, reporting, and verification |
 | `report-schema.json` | JSON schema for `findings.json` (confirmed and rejected finding structures) |
 | `validate-findings.cjs` | Zero-dependency Node.js validator that checks `findings.json` against the schema |
+| `findings-to-sarif.cjs` | Zero-dependency Node.js converter from `findings.json` to SARIF 2.1.0 |
 
 ## Installation
 

--- a/skills/security-audit/findings-to-sarif.cjs
+++ b/skills/security-audit/findings-to-sarif.cjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+
+/**
+ * Converts findings.json to SARIF 2.1.0 so audit results plug into the
+ * existing security toolchain: GitHub code scanning, VS Code SARIF viewers,
+ * DefectDojo, and any other SARIF consumer.
+ * Usage: node findings-to-sarif.cjs <path-to-findings.json> [output.sarif]
+ *        (writes to stdout when no output path is given)
+ *
+ * Mapping notes:
+ * - Only "confirmed" findings become SARIF results. "rejected" findings are
+ *   excluded from results but counted in run.properties.rejectedFindings so
+ *   the audit trail stays visible.
+ * - The finding's trace (entrypoint → propagation → sink) maps to a SARIF
+ *   codeFlow, which GitHub code scanning renders as a step-through path.
+ *   The sink is used as the result's primary location — that is where the
+ *   defect manifests and where a fix lands.
+ * - overall_severity maps to SARIF level (critical/high → error,
+ *   medium → warning, low/informational → note) and to the GitHub
+ *   "security-severity" rule property for code scanning's severity buckets.
+ * - partialFingerprints hashes the raw UTF-8 octets of stable finding
+ *   identity fields (never a re-encoded/pretty-printed form), so the same
+ *   finding keeps the same fingerprint across runs and platforms.
+ *
+ * Run validate-findings.cjs first; this converter assumes schema-valid input.
+ * Zero dependencies. Exits 0 on success, 1 on failure.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+const inputPath = process.argv[2];
+const outputPath = process.argv[3];
+if (!inputPath) {
+	console.error("Usage: node findings-to-sarif.cjs <path-to-findings.json> [output.sarif]");
+	process.exit(1);
+}
+
+let findings;
+try {
+	findings = JSON.parse(fs.readFileSync(inputPath, "utf8"));
+} catch (e) {
+	console.error("Failed to parse JSON:", e.message);
+	process.exit(1);
+}
+if (!Array.isArray(findings)) {
+	console.error("findings.json must be an array");
+	process.exit(1);
+}
+
+// --- Mapping helpers ------------------------------------------------------------
+
+const LEVEL_BY_SEVERITY = {
+	critical: "error",
+	high: "error",
+	medium: "warning",
+	low: "note",
+	informational: "note",
+};
+
+// GitHub code scanning buckets: critical >= 9.0, high >= 7.0, medium >= 4.0.
+const SECURITY_SEVERITY_SCORE = {
+	critical: "9.5",
+	high: "7.5",
+	medium: "5.0",
+	low: "2.5",
+	informational: "0.0",
+};
+
+function slugify(title, index) {
+	const slug = String(title || "")
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 80);
+	return slug || `finding-${index}`;
+}
+
+// Fingerprint over the raw UTF-8 octets of the identity fields, joined with an
+// unambiguous separator. Hashing raw octets (not a pretty-printed or otherwise
+// re-encoded form) keeps fingerprints stable across tools and platforms.
+function fingerprint(ruleId, sink, rootCause) {
+	const identity = [ruleId, sink ? sink.file : "", sink ? String(sink.line) : "", rootCause || ""].join("\u0000");
+	return crypto.createHash("sha256").update(Buffer.from(identity, "utf8")).digest("hex");
+}
+
+function toLocation(step) {
+	return {
+		physicalLocation: {
+			artifactLocation: { uri: step.file, uriBaseId: "SRCROOT" },
+			region: { startLine: step.line },
+		},
+		logicalLocations: [{ name: step.scope, kind: "function" }],
+		message: { text: `${step.kind}: ${step.description}` },
+	};
+}
+
+// --- Convert --------------------------------------------------------------------
+
+const rules = [];
+const ruleIndexById = new Map();
+const results = [];
+let rejected = 0;
+let skipped = 0;
+
+findings.forEach((f, i) => {
+	if (!f || typeof f !== "object" || f.verdict === "rejected") {
+		rejected += f && f.verdict === "rejected" ? 1 : 0;
+		skipped += f && f.verdict === "rejected" ? 0 : 1;
+		return;
+	}
+	if (f.verdict !== "confirmed") {
+		skipped++;
+		return;
+	}
+
+	const overall = (f.severity && f.severity.overall_severity) || "medium";
+	const ruleId = slugify(f.title, i);
+
+	if (!ruleIndexById.has(ruleId)) {
+		ruleIndexById.set(ruleId, rules.length);
+		rules.push({
+			id: ruleId,
+			name: ruleId,
+			shortDescription: { text: f.title || ruleId },
+			fullDescription: { text: f.intended_behavior || f.title || ruleId },
+			help: { text: (f.remediation && f.remediation.strategy) || "See finding description." },
+			properties: {
+				"security-severity": SECURITY_SEVERITY_SCORE[overall] || "5.0",
+			},
+		});
+	}
+
+	const trace = Array.isArray(f.trace) ? f.trace : [];
+	const sink = trace.length > 0 ? trace[trace.length - 1] : null;
+
+	const result = {
+		ruleId,
+		ruleIndex: ruleIndexById.get(ruleId),
+		level: LEVEL_BY_SEVERITY[overall] || "warning",
+		message: { text: `${f.description}\n\nRoot cause: ${f.root_cause}` },
+		partialFingerprints: {
+			"findingHash/v1": fingerprint(ruleId, sink, f.root_cause),
+		},
+		properties: {
+			verdict: f.verdict,
+			root_cause: f.root_cause,
+			intended_behavior: f.intended_behavior,
+			conditions: f.conditions,
+			execution: f.execution,
+			remediation: f.remediation,
+			severity: f.severity,
+			confidence: f.confidence,
+		},
+	};
+
+	if (sink) {
+		result.locations = [toLocation(sink)];
+	}
+	if (trace.length >= 2) {
+		result.codeFlows = [
+			{
+				threadFlows: [
+					{
+						locations: trace.map((step) => ({ location: toLocation(step) })),
+					},
+				],
+			},
+		];
+	}
+
+	results.push(result);
+});
+
+const sarif = {
+	$schema: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+	version: "2.1.0",
+	runs: [
+		{
+			tool: {
+				driver: {
+					name: "security-audit-skill",
+					informationUri: "https://github.com/cloudflare/security-audit-skill",
+					rules,
+				},
+			},
+			automationDetails: { id: `security-audit/${path.basename(inputPath)}` },
+			originalUriBaseIds: {
+				SRCROOT: { description: { text: "Root of the audited repository." } },
+			},
+			columnKind: "utf16CodeUnits",
+			results,
+			properties: {
+				confirmedFindings: results.length,
+				rejectedFindings: rejected,
+			},
+		},
+	],
+};
+
+const json = JSON.stringify(sarif, null, 2) + "\n";
+if (outputPath) {
+	fs.writeFileSync(outputPath, json);
+	console.log(`Wrote ${results.length} result(s) to ${outputPath} (${rejected} rejected finding(s) excluded)`);
+} else {
+	process.stdout.write(json);
+}
+if (skipped > 0) {
+	console.error(`WARNING: ${skipped} entr(y/ies) had no recognized verdict and were skipped`);
+}


### PR DESCRIPTION
## What

Adds `findings-to-sarif.cjs`, a zero-dependency converter from `findings.json` to **SARIF 2.1.0**, so audit output plugs directly into GitHub code scanning, VS Code SARIF viewers, DefectDojo, and any other SARIF consumer — no post-processing.

```bash
node findings-to-sarif.cjs <output-dir>/findings.json <output-dir>/findings.sarif
```

## Why

The skill already produces excellent structured output, but `findings.json` uses the skill's own schema. SARIF is the interchange format the surrounding tooling already speaks — emitting it lets a security-audit run surface as annotations on a PR (code scanning) or as navigable results in an IDE without anyone writing glue.

## Mapping choices

- **Only `confirmed` findings become results.** `rejected` findings are excluded from `results` but counted in `run.properties.rejectedFindings`, so the adversarial-validation trail stays visible rather than silently dropped.
- **`trace` → `codeFlow`.** The entrypoint → propagation → sink chain maps to a SARIF `codeFlow`, which code scanning renders as a step-through path. The **sink** is the result's primary `location` — where the defect manifests and where a fix lands.
- **`overall_severity` → `level` + `security-severity`.** `critical`/`high` → `error`, `medium` → `warning`, `low`/`informational` → `note`; plus the numeric `security-severity` rule property that drives code scanning's severity buckets.
- **`partialFingerprints`** hash the raw UTF-8 octets of stable identity fields (rule id, sink file/line, root cause), so a finding keeps the same fingerprint across runs and platforms and code scanning can dedupe it.

## Notes

- **Zero dependencies**, matching `validate-findings.cjs`. Run the validator first; this converter assumes schema-valid input.
- Output validated against the [OASIS SARIF 2.1.0 schema](https://github.com/oasis-tcs/sarif-spec) (confirmed + rejected fixture → `codeFlow`, severity mapping, fingerprint all check out).
- Additive only — no change to the existing pipeline, schema, or validator.

Happy to adjust the mapping (e.g. surface `conditions`/`execution` differently, or emit one run per hunting class) if you'd prefer a different shape.
