### PR TITLE
fix: reject invalid trace line numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "security-audit-skill",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/skills/security-audit/report-schema.json
+++ b/skills/security-audit/report-schema.json
@@ -41,7 +41,8 @@
                   "description": "Exact file path relative to repository root."
                 },
                 "line": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 1
                 },
                 "scope": {
                   "type": "string",

--- a/skills/security-audit/validate-findings.cjs
+++ b/skills/security-audit/validate-findings.cjs
@@ -7,7 +7,7 @@
  * The validation rules live in report-schema.json — the single source of truth.
  * This script reads that schema at runtime and interprets the subset of JSON
  * Schema it uses: type (object|array|string|integer), properties, required,
- * additionalProperties:false, enum, const, items, minItems, and oneOf.
+ * additionalProperties:false, enum, const, items, minItems, minimum, and oneOf.
  *
  * Some constraints can't be expressed in that subset (a confirmed trace must
  * start at an "entrypoint", end at a "sink", and only use "propagation" for
@@ -104,6 +104,10 @@ function validate(value, schema, p, errors) {
 	if (schema.enum && !schema.enum.includes(value)) {
 		const allowed = schema.enum.map((v) => JSON.stringify(v)).join(", ");
 		errors.push(`${p}: invalid value ${JSON.stringify(value)} (expected one of ${allowed})`);
+	}
+
+	if (typeof schema.minimum === "number" && typeof value === "number" && value < schema.minimum) {
+		errors.push(`${p}: must be >= ${schema.minimum}, got ${value}`);
 	}
 
 	switch (schema.type) {

--- a/test/validate-findings.test.cjs
+++ b/test/validate-findings.test.cjs
@@ -1,0 +1,76 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const { mkdtempSync, rmSync, writeFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const path = require("node:path");
+const { describe, test } = require("node:test");
+
+const validator = path.join(__dirname, "..", "skills", "security-audit", "validate-findings.cjs");
+
+function confirmedFinding(line) {
+  const traceStep = (kind, scope) => ({
+    kind,
+    file: "src/app.js",
+    line,
+    scope,
+    description: `${kind} description`,
+  });
+
+  return {
+    verdict: "confirmed",
+    title: "Example finding",
+    description: "Example description",
+    root_cause: "handler in src/app.js does not validate input, allowing unauthorized access",
+    intended_behavior: "The handler rejects unauthorized access.",
+    trace: [traceStep("entrypoint", "handler"), traceStep("sink", "readSecret")],
+    conditions: [],
+    execution: {
+      attacker_perspective: "An unauthenticated remote user.",
+      payloads: ["GET /secret"],
+      instructions: ["Send the request."],
+      expected_result: "The response contains the secret.",
+    },
+    remediation: { strategy: "Validate authorization before reading the secret." },
+    severity: {
+      likelihood: { score: "high", reason: "The endpoint is public." },
+      impact: { score: "high", reason: "The response exposes a secret." },
+      overall_severity: "high",
+    },
+    confidence: { score: "high", reason: "The trace was reproduced." },
+  };
+}
+
+function validateLine(line) {
+  const directory = mkdtempSync(path.join(tmpdir(), "security-audit-validator-"));
+  const findingsPath = path.join(directory, "findings.json");
+  writeFileSync(findingsPath, JSON.stringify([confirmedFinding(line)]));
+
+  try {
+    return spawnSync(process.execPath, [validator, findingsPath], { encoding: "utf8" });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+describe("trace line validation", () => {
+  test("accepts positive source lines", () => {
+    const result = validateLine(1);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /PASS: 1 findings valid/);
+  });
+
+  test("rejects line zero", () => {
+    const result = validateLine(0);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /line: must be >= 1, got 0/);
+  });
+
+  test("rejects negative source lines", () => {
+    const result = validateLine(-1);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /line: must be >= 1, got -1/);
+  });
+});


### PR DESCRIPTION
## Summary
Require every `trace[].line` reference to be a positive source line and add regression coverage for the findings validator.

## Why
The schema currently accepts any integer. As a result, confirmed findings with line `0` or a negative line pass validation even though those locations cannot refer to source code. This weakens the machine-readable evidence contract used by independent verification.

The patch adds `minimum: 1` to the schema and teaches the zero-dependency schema interpreter to enforce numeric `minimum` constraints generically.

## Testing
- `npm test`
- Direct validator smoke test with a valid confirmed finding

The test suite executes `validate-findings.cjs` as a subprocess and covers a positive line, zero, and a negative line.